### PR TITLE
Support complex request bodies like those used for custom keyboards

### DIFF
--- a/lib/telegrambot.js
+++ b/lib/telegrambot.js
@@ -70,7 +70,31 @@ TelegramBot.request = function(id, method, opts, cb) {
     };
 
     // Assign the form data only if it is popualted
-    if (Object.keys(opts).length) settings.formData = opts;
+    var keys = Object.keys(opts)
+    if (keys.length) {
+        var hasFiles = keys.some(function (key) {
+            var data = opts[key];
+            if (! data) return false;
+
+            // See custom_file example
+            // https://github.com/request/request#multipartform-data-multipart-form-uploads
+            var isFileShape = data.value && data.options;
+            var isFileValue = (
+                typeof data.value !== 'string' &&
+                typeof data.value !== 'number' &&
+                typeof data.value !== 'boolean'
+            );
+            return isFileShape && isFileValue;
+        })
+
+        // Uploading files must use multipart form request
+        // Other requests should use JSON to support nested objects in bodies
+        if (hasFiles) {
+            settings.formData = opts;
+        } else {
+            settings.body = opts;
+        }
+    }
 
     request.post(settings, TelegramBot.unwrap(cb));
     return this;


### PR DESCRIPTION
When a request has parameters they are currently sent as a multipart form request [here](https://github.com/arcturial/telegrambot/blob/ee57c781a9cc3b7f328fd2eaa6a9b37908d04acb/lib/telegrambot.js#L73). This works fine when the params are simple data (strings, booleans, numbers) but causes a problem when any of the params are objects.

Here's an example of problematic code.

``` js
api.sendMessage({
  chat_id: 1234,
  text: 'Hello, world',
  reply_markup: {
    keyboard: [['An option'], ['Another option']],
  },
}, console.log.bind(console))
```

Running this will throw a pretty confusing error from the `combined-stream` module, which is used internally by `request`. I think the underlying issue is that multipart form requests just don't allow this sort of nested data structure.

But sometimes multipart requests are needed, because they are required to upload files.

This PR tries to choose the correct request type based on the parameters so that normal requests, complex request, and upload requests will work.
