### PR TITLE
use http GET for getMe, otherwise nginx will deny with error 504

### DIFF
--- a/lib/telegrambot.js
+++ b/lib/telegrambot.js
@@ -75,7 +75,8 @@ TelegramBot.request = function(id, method, opts, cb) {
     if (opts.reply_markup) opts.reply_markup = JSON.stringify(opts.reply_markup);
 
     settings.formData = opts;
-
+    (method == 'getMe') ?
+    request.get(settings, TelegramBot.unwrap(cb)) :
     request.post(settings, TelegramBot.unwrap(cb));
     return this;
 }


### PR DESCRIPTION
Fix the error where using `request.post` for `getMe` will cause Telegram Nginx to reject request with error 504.

Sample error log:

``` shell
[Sat Apr 23 2016 18:04:05 GMT-0400 (EDT)] ERROR Error: HTTP status 504 returned.
  at Function.TelegramBot.error (/Users/theredrose/Documents/aiva/node_modules/telegrambot/lib/telegrambot.js:26:15)
  at Request._callback (/Users/theredrose/Documents/aiva/node_modules/telegrambot/lib/telegrambot.js:48:62)
  at Request.self.callback (/Users/theredrose/Documents/aiva/node_modules/request/request.js:200:22)
  at emitTwo (events.js:87:13)
  at Request.emit (events.js:172:7)
  at Request.<anonymous> (/Users/theredrose/Documents/aiva/node_modules/request/request.js:1067:10)
  at emitOne (events.js:82:20)
  at Request.emit (events.js:169:7)
  at IncomingMessage.<anonymous> (/Users/theredrose/Documents/aiva/node_modules/request/request.js:988:12)
  at emitNone (events.js:72:20)
  at IncomingMessage.emit (events.js:166:7)
  at endReadableNT (_stream_readable.js:905:12)
  at nextTickCallbackWith2Args (node.js:474:9)
  at process._tickCallback (node.js:388:17)
```
